### PR TITLE
feat(release): change semantic-release strategy

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: The git committer email address
     required: false
     default: 'hoid@zefiros.io'
+  beta_release:
+    description: Create beta release
+    required: false
+    default: 'false'
 
 runs:
   using: 'composite'
@@ -21,6 +25,7 @@ runs:
       run: npx semantic-release
       shell: bash
       env:
+        BETA_RELEASE: ${{ inputs.beta_release == 'true' && 'true' || 'false' }}
         GIT_AUTHOR_NAME: ${{ inputs.git_author }}
         GIT_COMMITTER_NAME: ${{ inputs.git_author }}
         GIT_AUTHOR_EMAIL: ${{ inputs.git_email }}
@@ -29,6 +34,7 @@ runs:
       run: npx semantic-release --dry-run
       shell: bash
       env:
+        BETA_RELEASE: ${{ inputs.beta_release == 'true' && 'true' || 'false' }}
         GIT_AUTHOR_NAME: ${{ inputs.git_author }}
         GIT_COMMITTER_NAME: ${{ inputs.git_author }}
         GIT_AUTHOR_EMAIL: ${{ inputs.git_email }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,17 +1,24 @@
 name: Typescript Package CI
 
-on: push
+on: 
+  push:
+  workflow_dispatch:
+      inputs:
+        beta_release:
+          description: Create beta release
+          required: true
+          type: boolean
 
 jobs:
   typescript:
-    uses: skyleague/node-standards/.github/workflows/reusable-typescript.yml@next
+    uses: skyleague/node-standards/.github/workflows/reusable-typescript.yml@main
     with:
       standards_postinstall: npm link
     secrets:
       GITHUB_NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build:
-    uses: skyleague/node-standards/.github/workflows/reusable-build.yml@next
+    uses: skyleague/node-standards/.github/workflows/reusable-build.yml@main
     secrets:
       GITHUB_NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -25,7 +32,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: ${{ needs.build.outputs.artifact_name }}
-      - uses: skyleague/node-standards/.github/actions/setup-node@next
+      - uses: skyleague/node-standards/.github/actions/setup-node@main
         with:
           working-directory: examples/library/
           global-packages: yalc
@@ -45,7 +52,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: ${{ needs.build.outputs.artifact_name }}
-      - uses: skyleague/node-standards/.github/actions/setup-node@next
+      - uses: skyleague/node-standards/.github/actions/setup-node@main
         with:
           working-directory: examples/yargs-cli/
           global-packages: yalc
@@ -57,8 +64,9 @@ jobs:
 
   release:
     needs: [library, yargs, typescript, build]
-    uses: skyleague/node-standards/.github/workflows/reusable-release.yml@next
+    uses: skyleague/node-standards/.github/workflows/reusable-release.yml@main
     with:
       build_artifact_name: ${{ needs.build.outputs.artifact_name }}
+      beta_release: ${{ inputs.beta_release || false }}
     secrets:
       GITHUB_NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: skyleague/node-standards/.github/actions/setup-node@next
+      - uses: skyleague/node-standards/.github/actions/setup-node@main
         env:
           GITHUB_NPM_TOKEN: ${{ secrets.GITHUB_NPM_TOKEN }}
       - run: npm run build

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -3,6 +3,11 @@ name: Reusable release pipeline for NodeJS projects
 on:
   workflow_call:
     inputs:
+      beta_release:
+        description: Create beta release
+        type: boolean
+        required: false
+        default: false
       build_artifact_name:
         description: Name of the build artifact
         type: string
@@ -30,12 +35,13 @@ jobs:
         with:
           name: ${{ inputs.build_artifact_name }}
           path: ${{ inputs.build_artifact_path }}
-      - uses: skyleague/node-standards/.github/actions/setup-node@next
+      - uses: skyleague/node-standards/.github/actions/setup-node@main
         env:
           GITHUB_NPM_TOKEN: ${{ secrets.GITHUB_NPM_TOKEN }}
-      - uses: skyleague/node-standards/.github/actions/release@next
+      - uses: skyleague/node-standards/.github/actions/release@main
         with:
-          dry_run: ${{ (github.ref == 'refs/heads/next' || github.ref == 'refs/heads/main') && 'false' || 'true' }}
+          dry_run: ${{ (github.ref == 'refs/heads/next' || github.ref == 'refs/heads/main' || inputs.beta_release) && 'false' || 'true' }}
+          beta_release: ${{ inputs.beta_release && 'true' || 'false' }}
         env:
           # Uses GITHUB_TOKEN for publish permissions
           GITHUB_NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -55,7 +61,7 @@ jobs:
     if: ${{ inputs.publish_docs == 'true' && (github.ref == 'refs/heads/next' || github.ref == 'refs/heads/main') }}
     steps:
       - uses: actions/checkout@v3
-      - uses: skyleague/node-standards/.github/actions/setup-node@next
+      - uses: skyleague/node-standards/.github/actions/setup-node@main
         env:
           GITHUB_NPM_TOKEN: ${{ secrets.GITHUB_NPM_TOKEN }}
       - run: npm run build:docs

--- a/.github/workflows/reusable-typescript.yml
+++ b/.github/workflows/reusable-typescript.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: skyleague/node-standards/.github/actions/setup-node@next
+      - uses: skyleague/node-standards/.github/actions/setup-node@main
         env:
           GITHUB_NPM_TOKEN: ${{ secrets.GITHUB_NPM_TOKEN }}
       - run: npm run lint
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: skyleague/node-standards/.github/actions/setup-node@next
+      - uses: skyleague/node-standards/.github/actions/setup-node@main
         with:
           postinstall: ${{ inputs.standards_postinstall }}
         env:
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: skyleague/node-standards/.github/actions/setup-node@next
+      - uses: skyleague/node-standards/.github/actions/setup-node@main
         env:
           GITHUB_NPM_TOKEN: ${{ secrets.GITHUB_NPM_TOKEN }}
       - run: npm run check:types
@@ -67,7 +67,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: skyleague/node-standards/.github/actions/setup-node@next
+      - uses: skyleague/node-standards/.github/actions/setup-node@main
         env:
           GITHUB_NPM_TOKEN: ${{ secrets.GITHUB_NPM_TOKEN }}
       - run: npm run check:coverage

--- a/examples/library/.github/workflows/package.yml
+++ b/examples/library/.github/workflows/package.yml
@@ -4,18 +4,18 @@ on: push
 
 jobs:
   typescript:
-    uses: skyleague/node-standards/.github/workflows/reusable-typescript.yml@next
+    uses: skyleague/node-standards/.github/workflows/reusable-typescript.yml@main
     secrets:
       GITHUB_NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build:
-    uses: skyleague/node-standards/.github/workflows/reusable-build.yml@next
+    uses: skyleague/node-standards/.github/workflows/reusable-build.yml@main
     secrets:
       GITHUB_NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   release:
     needs: [typescript, build]
-    uses: skyleague/node-standards/.github/workflows/reusable-release.yml@next
+    uses: skyleague/node-standards/.github/workflows/reusable-release.yml@main
     with:
       build_artifact_name: ${{ needs.build.outputs.artifact_name }}
     secrets:

--- a/examples/yargs-cli/.github/workflows/package.yml
+++ b/examples/yargs-cli/.github/workflows/package.yml
@@ -4,18 +4,18 @@ on: push
 
 jobs:
   typescript:
-    uses: skyleague/node-standards/.github/workflows/reusable-typescript.yml@next
+    uses: skyleague/node-standards/.github/workflows/reusable-typescript.yml@main
     secrets:
       GITHUB_NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build:
-    uses: skyleague/node-standards/.github/workflows/reusable-build.yml@next
+    uses: skyleague/node-standards/.github/workflows/reusable-build.yml@main
     secrets:
       GITHUB_NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   release:
     needs: [typescript, build]
-    uses: skyleague/node-standards/.github/workflows/reusable-release.yml@next
+    uses: skyleague/node-standards/.github/workflows/reusable-release.yml@main
     with:
       build_artifact_name: ${{ needs.build.outputs.artifact_name }}
     secrets:

--- a/release.config.js
+++ b/release.config.js
@@ -1,5 +1,16 @@
 module.exports = {
-    branches: [{ name: 'main' }, { name: 'next', channel: 'next', prerelease: 'beta' }],
+    branches: [
+        { name: 'main' },
+        ...(process.env.BETA_RELEASE === 'true'
+            ? [
+                  {
+                      name: gitBranch(),
+                      channel: 'beta',
+                      prerelease: `beta-${gitSha().substring(0, 8)}`,
+                  },
+              ]
+            : []),
+    ],
     plugins: [
         [
             '@semantic-release/commit-analyzer',
@@ -24,4 +35,19 @@ module.exports = {
         '@semantic-release/github',
         '@semantic-release/npm',
     ],
+}
+
+function gitSha() {
+    return (
+        process.env.GITHUB_SHA ??
+        // Fallback, will not be executed in CI environments
+        require('child_process').execSync('git rev-parse HEAD', { cwd: process.cwd(), encoding: 'utf-8' })
+    )
+}
+function gitBranch() {
+    return (
+        process.env.GITHUB_REF_NAME ??
+        // Fallback, will not be executed in CI environments
+        require('child_process').execSync('git rev-parse --abbrev-ref HEAD', { cwd: process.cwd(), encoding: 'utf-8' })
+    )
 }

--- a/templates/library/.github/workflows/package.yml
+++ b/templates/library/.github/workflows/package.yml
@@ -4,18 +4,18 @@ on: push
 
 jobs:
   typescript:
-    uses: skyleague/node-standards/.github/workflows/reusable-typescript.yml@next
+    uses: skyleague/node-standards/.github/workflows/reusable-typescript.yml@main
     secrets:
       GITHUB_NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build:
-    uses: skyleague/node-standards/.github/workflows/reusable-build.yml@next
+    uses: skyleague/node-standards/.github/workflows/reusable-build.yml@main
     secrets:
       GITHUB_NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   release:
     needs: [typescript, build]
-    uses: skyleague/node-standards/.github/workflows/reusable-release.yml@next
+    uses: skyleague/node-standards/.github/workflows/reusable-release.yml@main
     with:
       build_artifact_name: ${{ needs.build.outputs.artifact_name }}
     secrets:

--- a/templates/yargs-cli/.github/workflows/package.yml
+++ b/templates/yargs-cli/.github/workflows/package.yml
@@ -4,18 +4,18 @@ on: push
 
 jobs:
   typescript:
-    uses: skyleague/node-standards/.github/workflows/reusable-typescript.yml@next
+    uses: skyleague/node-standards/.github/workflows/reusable-typescript.yml@main
     secrets:
       GITHUB_NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build:
-    uses: skyleague/node-standards/.github/workflows/reusable-build.yml@next
+    uses: skyleague/node-standards/.github/workflows/reusable-build.yml@main
     secrets:
       GITHUB_NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   release:
     needs: [typescript, build]
-    uses: skyleague/node-standards/.github/workflows/reusable-release.yml@next
+    uses: skyleague/node-standards/.github/workflows/reusable-release.yml@main
     with:
       build_artifact_name: ${{ needs.build.outputs.artifact_name }}
     secrets:


### PR DESCRIPTION
Change the release strategy to only release from `main` by default. Allow manual `beta` releases on any other branch using `workflow_dispatch` as a trigger.
