### PR TITLE
fix: optimize cicd workflow for this package

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -16,15 +16,27 @@ on:
         type: boolean
 
 jobs:
+  optimize_ci:
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.check_skip.outputs.skip }}
+    steps:
+      - name: Optimize CI
+        id: check_skip
+        uses: withgraphite/graphite-ci-action@main
+        with:
+          graphite_token: ${{ secrets.GRAPHITE_CI_OPTIMIZER_TOKEN }}
+
   typescript:
+    needs: [optimize_ci]
+    if: needs.optimize_ci.outputs.skip == 'false'
     uses: skyleague/node-standards/.github/workflows/reusable-typescript.yml@main
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-    with:
-      npm-args: '--workspaces'
 
   release:
-    needs: [typescript]
+    needs: [typescript,optimize_ci]
+    if: needs.optimize_ci.outputs.skip == 'false'
     uses: skyleague/node-standards/.github/workflows/reusable-release.yml@main
     with:
       build_artifact_name: ${{ needs.typescript.outputs.artifact-name }}

--- a/examples/library/.github/workflows/package.yml
+++ b/examples/library/.github/workflows/package.yml
@@ -28,12 +28,15 @@ jobs:
           graphite_token: ${{ secrets.GRAPHITE_CI_OPTIMIZER_TOKEN }}
 
   typescript:
+    needs: [optimize_ci]
+    if: needs.optimize_ci.outputs.skip == 'false'
     uses: skyleague/node-standards/.github/workflows/reusable-typescript.yml@main
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   release:
-    needs: [typescript]
+    needs: [typescript,optimize_ci]
+    if: needs.optimize_ci.outputs.skip == 'false'
     uses: skyleague/node-standards/.github/workflows/reusable-release.yml@main
     with:
       build_artifact_name: ${{ needs.typescript.outputs.artifact-name }}

--- a/examples/yargs-cli/.github/workflows/package.yml
+++ b/examples/yargs-cli/.github/workflows/package.yml
@@ -28,12 +28,15 @@ jobs:
           graphite_token: ${{ secrets.GRAPHITE_CI_OPTIMIZER_TOKEN }}
 
   typescript:
+    needs: [optimize_ci]
+    if: needs.optimize_ci.outputs.skip == 'false'
     uses: skyleague/node-standards/.github/workflows/reusable-typescript.yml@main
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   release:
-    needs: [typescript]
+    needs: [typescript,optimize_ci]
+    if: needs.optimize_ci.outputs.skip == 'false'
     uses: skyleague/node-standards/.github/workflows/reusable-release.yml@main
     with:
       build_artifact_name: ${{ needs.typescript.outputs.artifact-name }}

--- a/templates/common-typescript/.github/workflows/package.yml
+++ b/templates/common-typescript/.github/workflows/package.yml
@@ -28,12 +28,15 @@ jobs:
           graphite_token: ${{ secrets.GRAPHITE_CI_OPTIMIZER_TOKEN }}
 
   typescript:
+    needs: [optimize_ci]
+    if: needs.optimize_ci.outputs.skip == 'false'
     uses: skyleague/node-standards/.github/workflows/reusable-typescript.yml@main
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   release:
-    needs: [typescript]
+    needs: [typescript,optimize_ci]
+    if: needs.optimize_ci.outputs.skip == 'false'
     uses: skyleague/node-standards/.github/workflows/reusable-release.yml@main
     with:
       build_artifact_name: ${{ needs.typescript.outputs.artifact-name }}


### PR DESCRIPTION
This pull request introduces the 'optimize_ci' job to the CI/CD workflow configurations across multiple projects and templates. The job uses the 'withgraphite/graphite-ci-action@main' action to determine if the CI should be skipped for certain changes, thereby optimizing the workflow. The 'typescript' and 'release' jobs have been updated to depend on the outcome of the 'optimize_ci' job, reducing unnecessary runs and improving efficiency.

---

