### PR TITLE
fix: remove workspace support for docusaurus

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -96,7 +96,15 @@ jobs:
     if: ${{ inputs.publish_docs == 'true' && (github.ref == 'refs/heads/next' || github.ref == 'refs/heads/main') }}
     steps:
       - uses: actions/checkout@v4
-      - uses: skyleague/node-standards/.github/actions/setup-js@main
+      - name: Create semantic-release cache file
+        run: touch documentation
+      - uses: actions/setup-node@v4
+        with:
+          cache: 'npm'
+          node-version: ${{ inputs.node-version }}
+          cache-dependency-path: |
+            docs/package.json
+            package-lock.json
         env:
           GITHUB_NPM_TOKEN: ${{ secrets.GITHUB_NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/examples/library/docs/package.json
+++ b/examples/library/docs/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
+    "prebuild": "npm install",
     "build": "docusaurus build --out-dir=../.docs",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
@@ -16,8 +17,8 @@
     "@docusaurus/core": "^3.6.3",
     "@docusaurus/preset-classic": "^3.6.3",
     "@docusaurus/faster": "^3.6.3",
-    "@mdx-js/react": "^3.0.1",
-    "prism-react-renderer": "^2.3.1",
+    "@mdx-js/react": "^3.1.0",
+    "prism-react-renderer": "^2.4.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },
@@ -30,6 +31,6 @@
     "development": ["last 1 chrome version", "last 1 firefox version", "last 1 safari version"]
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   }
 }

--- a/examples/library/package.json
+++ b/examples/library/package.json
@@ -19,7 +19,7 @@
   "files": [".dist", "package.json"],
   "scripts": {
     "build": "tsc -p tsconfig.dist.json",
-    "build:docs": "npm run --workspace=docs build",
+    "build:docs": "npm run --prefix=docs build",
     "check:coverage": "vitest run --coverage=true",
     "check:project": "node-standards lint",
     "check:types": "tsc -p tsconfig.json",
@@ -44,6 +44,5 @@
   },
   "node-standards": {
     "extends": ["library", "docusaurus"]
-  },
-  "workspaces": ["docs"]
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       ],
       "dependencies": {
         "@biomejs/biome": "^1.9.4",
-        "@commitlint/cli": "^19.6.0",
+        "@commitlint/cli": "^19.6.1",
         "@commitlint/config-conventional": "^19.6.0",
         "@types/node": "^22.10.1",
         "@vitest/coverage-v8": "^2.1.8",
@@ -23,9 +23,8 @@
         "fast-glob": "^3.3.2",
         "find-root": "^1.1.0",
         "husky": "^9.1.7",
-        "is-ci": "^3.0.1",
         "line-diff": "^2.1.1",
-        "lint-staged": "^15.2.10",
+        "lint-staged": "^15.2.11",
         "semver": "^7.6.3",
         "tsx": "^4.19.2",
         "variable-diff": "^2.0.2",
@@ -36,7 +35,7 @@
         "node-standards": "bin/run.js"
       },
       "devDependencies": {
-        "@skyleague/therefore": "^6.1.0",
+        "@skyleague/therefore": "^6.1.2",
         "@types/find-root": "^1.1.4",
         "@types/is-ci": "^3.0.4",
         "@types/semver": "^7.5.8",
@@ -319,14 +318,14 @@
       }
     },
     "node_modules/@commitlint/cli": {
-      "version": "19.6.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-19.6.0.tgz",
-      "integrity": "sha512-v17BgGD9w5KnthaKxXnEg6KLq6DYiAxyiN44TpiRtqyW8NSq+Kx99mkEG8Qo6uu6cI5eMzMojW2muJxjmPnF8w==",
+      "version": "19.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-19.6.1.tgz",
+      "integrity": "sha512-8hcyA6ZoHwWXC76BoC8qVOSr8xHy00LZhZpauiD0iO0VYbVhMnED0da85lTfIULxl7Lj4c6vZgF0Wu/ed1+jlQ==",
       "license": "MIT",
       "dependencies": {
         "@commitlint/format": "^19.5.0",
         "@commitlint/lint": "^19.6.0",
-        "@commitlint/load": "^19.5.0",
+        "@commitlint/load": "^19.6.1",
         "@commitlint/read": "^19.5.0",
         "@commitlint/types": "^19.5.0",
         "tinyexec": "^0.3.0",
@@ -433,9 +432,9 @@
       }
     },
     "node_modules/@commitlint/load": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-19.5.0.tgz",
-      "integrity": "sha512-INOUhkL/qaKqwcTUvCE8iIUf5XHsEPCLY9looJ/ipzi7jtGhgmtH7OOFiNvwYgH7mA8osUWOUDV8t4E2HAi4xA==",
+      "version": "19.6.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-19.6.1.tgz",
+      "integrity": "sha512-kE4mRKWWNju2QpsCWt428XBvUH55OET2N4QKQ0bF85qS/XbsRGG1MiTByDNlEVpEPceMkDr46LNH95DtRwcsfA==",
       "license": "MIT",
       "dependencies": {
         "@commitlint/config-validator": "^19.5.0",
@@ -444,7 +443,7 @@
         "@commitlint/types": "^19.5.0",
         "chalk": "^5.3.0",
         "cosmiconfig": "^9.0.0",
-        "cosmiconfig-typescript-loader": "^5.0.0",
+        "cosmiconfig-typescript-loader": "^6.1.0",
         "lodash.isplainobject": "^4.0.6",
         "lodash.merge": "^4.6.2",
         "lodash.uniq": "^4.5.0"
@@ -1409,9 +1408,9 @@
       "link": true
     },
     "node_modules/@skyleague/therefore": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@skyleague/therefore/-/therefore-6.1.1.tgz",
-      "integrity": "sha512-c0T7DWU3tdsRRqqZfXRd+k7/oDeoxy4PIAZj65vq0wsaCLbG2N1LTYLcYs75LAZ4Z/w1eEsw3rgkphjI0q8qzQ==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@skyleague/therefore/-/therefore-6.1.2.tgz",
+      "integrity": "sha512-42yrVWY6OITiVmNfSDeW9eq6N84IkQLiyxzE74ODdz5Enu3Gmjfh7nU0LGsrtxmfP308O+H9BUmiSRS0v/19/g==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -1981,6 +1980,7 @@
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
       "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2455,20 +2455,20 @@
       }
     },
     "node_modules/cosmiconfig-typescript-loader": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-5.1.0.tgz",
-      "integrity": "sha512-7PtBB+6FdsOvZyJtlF3hEPpACq7RQX6BVGsgC7/lfVXnKMvNCu/XY3ykreqG5w/rBNdu2z8LCIKoF3kpHHdHlA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-6.1.0.tgz",
+      "integrity": "sha512-tJ1w35ZRUiM5FeTzT7DtYWAFFv37ZLqSRkGi2oeCK1gPhvaWjkAtfXvLmvE1pRfxxp9aQo6ba/Pvg1dKj05D4g==",
       "license": "MIT",
       "dependencies": {
-        "jiti": "^1.21.6"
+        "jiti": "^2.4.1"
       },
       "engines": {
-        "node": ">=v16"
+        "node": ">=v18"
       },
       "peerDependencies": {
         "@types/node": "*",
-        "cosmiconfig": ">=8.2",
-        "typescript": ">=4"
+        "cosmiconfig": ">=9",
+        "typescript": ">=5"
       }
     },
     "node_modules/cross-spawn": {
@@ -2527,9 +2527,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3214,18 +3214,6 @@
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "license": "MIT"
     },
-    "node_modules/is-ci": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
-      "integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ci-info": "^3.2.0"
-      },
-      "bin": {
-        "is-ci": "bin.js"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3373,12 +3361,12 @@
       }
     },
     "node_modules/jiti": {
-      "version": "1.21.6",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.6.tgz",
-      "integrity": "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
+      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
       "license": "MIT",
       "bin": {
-        "jiti": "bin/jiti.js"
+        "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/js-tokens": {
@@ -3480,21 +3468,21 @@
       "license": "MIT"
     },
     "node_modules/lint-staged": {
-      "version": "15.2.10",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.2.10.tgz",
-      "integrity": "sha512-5dY5t743e1byO19P9I4b3x8HJwalIznL5E1FWYnU6OWw33KxNBSLAc6Cy7F2PsFEO8FKnLwjwm5hx7aMF0jzZg==",
+      "version": "15.2.11",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.2.11.tgz",
+      "integrity": "sha512-Ev6ivCTYRTGs9ychvpVw35m/bcNDuBN+mnTeObCL5h+boS5WzBEC6LHI4I9F/++sZm1m+J2LEiy0gxL/R9TBqQ==",
       "license": "MIT",
       "dependencies": {
         "chalk": "~5.3.0",
         "commander": "~12.1.0",
-        "debug": "~4.3.6",
+        "debug": "~4.4.0",
         "execa": "~8.0.1",
-        "lilconfig": "~3.1.2",
-        "listr2": "~8.2.4",
+        "lilconfig": "~3.1.3",
+        "listr2": "~8.2.5",
         "micromatch": "~4.0.8",
         "pidtree": "~0.6.0",
         "string-argv": "~0.3.2",
-        "yaml": "~2.5.0"
+        "yaml": "~2.6.1"
       },
       "bin": {
         "lint-staged": "bin/lint-staged.js"
@@ -5892,9 +5880,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.1.tgz",
-      "integrity": "sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.1.tgz",
+      "integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@biomejs/biome": "^1.9.4",
-    "@commitlint/cli": "^19.6.0",
+    "@commitlint/cli": "^19.6.1",
     "@commitlint/config-conventional": "^19.6.0",
     "@types/node": "^22.10.1",
     "@vitest/coverage-v8": "^2.1.8",
@@ -46,9 +46,8 @@
     "fast-glob": "^3.3.2",
     "find-root": "^1.1.0",
     "husky": "^9.1.7",
-    "is-ci": "^3.0.1",
     "line-diff": "^2.1.1",
-    "lint-staged": "^15.2.10",
+    "lint-staged": "^15.2.11",
     "semver": "^7.6.3",
     "tsx": "^4.19.2",
     "variable-diff": "^2.0.2",
@@ -56,7 +55,7 @@
     "yargs": "^17.7.2"
   },
   "devDependencies": {
-    "@skyleague/therefore": "^6.1.0",
+    "@skyleague/therefore": "^6.1.2",
     "@types/find-root": "^1.1.4",
     "@types/is-ci": "^3.0.4",
     "@types/semver": "^7.5.8",

--- a/src/lib/templates/docusaurus.ts
+++ b/src/lib/templates/docusaurus.ts
@@ -7,10 +7,9 @@ export const DocusaurusTemplate: ProjectTemplate = {
     template: {
         repositoryUrl,
         scripts: {
-            'build:docs': 'npm run --workspace=docs build',
+            'build:docs': 'npm run --prefix=docs build',
         },
         devDependencies: {},
-        workspaces: ['docs'],
         roots: [rootDirectory],
     },
 }

--- a/templates/docusaurus/docs/package.json
+++ b/templates/docusaurus/docs/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
+    "prebuild": "npm install",
     "build": "docusaurus build --out-dir=../.docs",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
@@ -16,8 +17,8 @@
     "@docusaurus/core": "^3.6.3",
     "@docusaurus/preset-classic": "^3.6.3",
     "@docusaurus/faster": "^3.6.3",
-    "@mdx-js/react": "^3.0.1",
-    "prism-react-renderer": "^2.3.1",
+    "@mdx-js/react": "^3.1.0",
+    "prism-react-renderer": "^2.4.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },
@@ -30,6 +31,6 @@
     "development": ["last 1 chrome version", "last 1 firefox version", "last 1 safari version"]
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   }
 }


### PR DESCRIPTION
- Replace workspace commands with prefix commands
- Remove is-ci dependency
- Update dependencies
- Upgrade node engine to v22
- Update github workflow to use setup-node